### PR TITLE
Fix installation error by switching from Poetry to `setuptools` build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 repository = "https://github.com/ozguralp/gmapsapiscanner"
 
 [project.scripts]
-maps_api_scanner = "maps_api_scanner"
+gmapsapiscanner = "maps_api_scanner:main"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Hello @ozguralp 

After PR #28 introduced PEP compliance, users reported installation failures in issue #29 with both `pipx` and `pip`.

This PR fix #29 by switching the build backend from Poetry to setuptools, which handles standalone Python modules.

<img width="622" height="123" alt="image" src="https://github.com/user-attachments/assets/986141b6-4c98-4fbb-90a7-d0c0ab753f44" />

